### PR TITLE
chore: enable Dependabot version updates for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds `.github/dependabot.yml` configuring weekly grouped `github-actions` version updates for:

- `master` (default branch)


This keeps pinned action SHAs fresh on every actively-maintained branch, mitigating drift from upstream action security patches. PRs are grouped so all action bumps on a branch land as a single PR per week.